### PR TITLE
Enable FastFixtureTestCase on Django 1.8+

### DIFF
--- a/django_nose/fixture_tables.py
+++ b/django_nose/fixture_tables.py
@@ -10,18 +10,15 @@ import gzip
 import zipfile
 from itertools import product
 
+from django.apps import apps
 from django.conf import settings
 from django.core import serializers
 from django.db import router, DEFAULT_DB_ALIAS
 
-try:
-    from django.db.models import get_apps
-except ImportError:
-    from django.apps import apps
 
-    def get_apps():
-        """Emulate get_apps in Django 1.9 and later."""
-        return [a.models_module for a in apps.get_app_configs()]
+def get_apps():
+    """Emulate get_apps in Django 1.9 and later."""
+    return [a.models_module for a in apps.get_app_configs()]
 
 try:
     import bz2

--- a/django_nose/fixture_tables.py
+++ b/django_nose/fixture_tables.py
@@ -60,6 +60,12 @@ def tables_used_by_fixtures(fixture_labels, using=DEFAULT_DB_ALIAS):
 
     app_module_paths = []
     for app in get_apps():
+
+        # *Hopefully* just an artifact of testing, but at least one NoneType is
+        # returned by get_apps
+        if app is None:
+            continue
+
         if hasattr(app, '__path__'):
             # It's a 'models/' subpackage
             for path in app.__path__:

--- a/django_nose/testcases.py
+++ b/django_nose/testcases.py
@@ -37,6 +37,7 @@ class FastFixtureTestCase(test.TransactionTestCase):
     """
 
     cleans_up_after_itself = True  # This is the good kind of puppy.
+    fixtures = []  # Otherwise default is None & non-iterable.
 
     @classmethod
     def setUpClass(cls):
@@ -59,7 +60,7 @@ class FastFixtureTestCase(test.TransactionTestCase):
     def _fixture_setup(cls):
         """Load fixture data, and commit."""
         for db in cls._databases():
-            if (hasattr(cls, 'fixtures') and
+            if (getattr(cls, 'fixtures', None) and
                     getattr(cls, '_fb_should_setup_fixtures', True)):
                 # Iff the fixture-bundling test runner tells us we're the first
                 # suite having these fixtures, set them up:

--- a/runtests.sh
+++ b/runtests.sh
@@ -143,7 +143,7 @@ django_test() {
     fi
 }
 
-TESTAPP_COUNT=6
+TESTAPP_COUNT=8
 
 reset_env
 django_test "./manage.py test $NOINPUT" $TESTAPP_COUNT 'normal settings'

--- a/testapp/settings.py
+++ b/testapp/settings.py
@@ -29,6 +29,7 @@ DATABASES = {
 MIDDLEWARE_CLASSES = ()
 
 INSTALLED_APPS = [
+    'django.contrib.sites',
     'django_nose',
     'testapp',
 ]

--- a/testapp/test_fast_fixtures.py
+++ b/testapp/test_fast_fixtures.py
@@ -25,3 +25,11 @@ class HasFixturesTestCase(FastFixtureTestCase):
         choice = question.choice_set.get()
         self.assertEqual("Blue.", choice.choice_text)
         self.assertEqual(3, choice.votes)
+
+
+class MissingFixturesTestCase(FastFixtureTestCase):
+    """No fixtures defined."""
+
+    def test_anything(self):
+        """Run any test to ensure Testcase is loaded without fixtures."""
+        assert True

--- a/testapp/test_fast_fixtures.py
+++ b/testapp/test_fast_fixtures.py
@@ -1,0 +1,27 @@
+"""
+Tests for FastFixtureTestCase.
+
+These tests primarily verify that the TestCases load and tests run rather than
+specifically verifying how the TestCase handles the fixtures themselves.
+"""
+
+from datetime import datetime
+
+from django_nose.testcases import FastFixtureTestCase
+from testapp.models import Question
+
+
+class HasFixturesTestCase(FastFixtureTestCase):
+    """Tests that use a test fixture."""
+
+    fixtures = ["testdata.json"]
+
+    def test_fixture_loaded(self):
+        """Test that a FAST fixture was loaded."""
+        question = Question.objects.get()
+        self.assertEqual(
+            'What is your favorite color?', question.question_text)
+        self.assertEqual(datetime(1975, 4, 9), question.pub_date)
+        choice = question.choice_set.get()
+        self.assertEqual("Blue.", choice.choice_text)
+        self.assertEqual(3, choice.votes)


### PR DESCRIPTION
This changeset allows the `FastFixtureTestCase` to be used on Django 1.8+. 

This is _not_ a rewrite or a comprehensive set of tests for the test case class. It is however an incremental move forward testing a baseline, can `FastFixtureTestCase` be used in tests? The [first commit](522841a8cc6c4a602e490a2743e6cbf5d6a57b71) adds the basic test - which will fail - and next three, specifically 8cb7e91daf3984e3c79f10544a5507930e01b942 apply the changeset to pass.

I'm sure the `FastFixtureTestCase` could use some additional work, certainly additional testing, getting it working seems like a good start.

Also solves the issue in #200 where no fixtures are specified and the test case fails (a necessary fix for the application I'm supporting).

Does not solve problems specifically for #162 or #208 as those issues reference now unsupported versions of Django. I'd reckon those issues could probably be closed since they're out of date now.
