### PR TITLE
Prepare for release 1.4.7

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -7,13 +7,25 @@ ago in the Django world.  It keeps running because of the contributions of
 volunteers.  Thank you to everyone who uses django-nose, keeps your projects
 up-to-date, files detailed bugs, and submits patches.
 
-Maintainers
------------
+Project Leads
+-------------
+* John Whitlock (`jwhitlock <https://github.com/jwhitlock>`_)
+
+This is a `Jazzband <https://jazzband.co>`_ project, supported by the members,
+who agree to abide by the
+`Contributor Code of Conduct <https://jazzband.co/about/conduct>`_ and follow the
+`guidelines <https://jazzband.co/about/guidelines>`_.
+If you'd like to become a project lead, please take a look at the
+`Releases documentation <https://jazzband.co/about/releases>`_ and reach out to us.
+
+Emeritus Maintainers
+--------------------
+Thank you for years of maintaining this project!
+
 * Jeff Balogh (`jbalogh <https://github.com/jbalogh>`_)
 * Erik Rose (`erikrose <https://github.com/erikrose>`_)
 * James Socol (`jscol <https://github.com/jsocol>`_)
 * Rob Hudson (`robhudson <https://github.com/robhudson>`_)
-* John Whitlock (`jwhitlock <https://github.com/jwhitlock>`_)
 
 Contributors
 ------------
@@ -31,6 +43,7 @@ These non-maintainers have contributed code to a django-nose release:
 * Conrado Buhrer (`conrado <https://github.com/conrado>`_)
 * David Baumgold (`singingwolfboy <https://github.com/singingwolfboy>`_)
 * David Cramer (`dcramer <https://github.com/dcramer>`_)
+* Dillon Lareau (`dlareau <https://github.com/dlareau>`_)
 * Dmitry Gladkov (`dgladkov <https://github.com/dgladkov>`_)
 * Ederson Mota (`edrmp <https://github.com/edrmp>`_)
 * Eric Zarowny (`ezarowny <https://github.com/ezarowny>`_)
@@ -38,6 +51,7 @@ These non-maintainers have contributed code to a django-nose release:
 * Fred Wenzel (`fwenzel <https://github.com/fwenzel>`_)
 * Fábio Santos (`fabiosantoscode <https://github.com/fabiosantoscode>`_)
 * Ionel Cristian Mărieș (`ionelmc <https://github.com/ionelmc>`_)
+* Jannis Leidel (`jezdez <https://github.com/jezdez>`_)
 * Jeremy Satterfield (`jsatt <https://github.com/jsatt>`_)
 * Johan Euphrosine (`proppy <https://github.com/proppy>`_)
 * Kyle Robertson (`dvelyk <https://github.com/dvelyk>`_)

--- a/README.rst
+++ b/README.rst
@@ -57,6 +57,21 @@ recommended.  It follows the `Django's support policy`_, supporting:
 .. _latest release: https://pypi.python.org/pypi/nose
 .. _Django's support policy: https://docs.djangoproject.com/en/1.8/internals/release-process/#supported-versions
 
+
+Note to users
+-------------
+
+`nose`_ has been in maintenance mode since at least 2015. ``django-nose`` is in
+maintenance mode as well, and the sole maintainer is no longer an active user.
+See `Jazzband.co`_ to learn how ``django-nose`` is maintained and how you can
+help. New projects should consider using `pytest`_, or `unittest`_ with the
+`Django testing framework`_.
+
+.. _Jazzband.co: https://jazzband.co
+.. _pytest: https://docs.pytest.org/en/stable/
+.. _unittest: https://docs.python.org/3/library/unittest.html
+.. _Django testing framework: https://docs.djangoproject.com/en/3.1/topics/testing/
+
 Installation
 ------------
 

--- a/changelog.rst
+++ b/changelog.rst
@@ -1,6 +1,14 @@
 Changelog
 ---------
 
+1.4.7 (2020-08-19)
+~~~~~~~~~~~~~~~~~~
+* Document Django 2.2 support, no changes needed
+* Move project to `Jazzband.co <https://jazzband.co>`_
+* Fix fixture loading on MySQL
+  (`issue 307 <https://github.com/jazzband/django-nose/issues/307>`_,
+  `dlareau <https://github.com/dlareau>`_)
+
 1.4.6 (2018-10-03)
 ~~~~~~~~~~~~~~~~~~
 * Document Django 2.0 and 2.1 support, no changes needed

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
 """django-nose packaging."""
 from __future__ import unicode_literals
 import os
@@ -37,13 +39,13 @@ _(Older changes can be found in the full documentation)._
 
 setup(
     name='django-nose',
-    version='1.4.6',
+    version='1.4.7',
     description='Makes your Django tests simple and snappy',
     long_description=get_long_description('django-nose'),
     author='Jeff Balogh',
     author_email='me@jeffbalogh.org',
-    maintainer='Erik Rose',
-    maintainer_email='erikrose@grinchcentral.com',
+    maintainer='John Whitlock',
+    maintainer_email='jwhitlock@mozilla.com',
     url='http://github.com/jazzband/django-nose',
     license='BSD',
     packages=find_packages(exclude=['testapp', 'testapp/*']),


### PR DESCRIPTION
* Update the authors and changelog for the 1.4.7 release.
* Update the maintainers list to reflect the current maintainers
* Add a note about the state of [nose](https://nose.readthedocs.io/en/latest/) and this project (fixes #310)